### PR TITLE
Fix linting error

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         ".": {
             "import": "./dist/index.mjs",
             "require": "./dist/index.cjs"
+            "types": "./dist/types/index.d.ts"
         }
     },
     "keywords": [


### PR DESCRIPTION
# Fix linting error by updating package.json

## My Problem
```ts
import { optimizeCssModules } from 'vite-plugin-optimize-css-modules';
```

#### VSCode linting
There are types at `'<workspace>/node_modules/vite-plugin-optimize-css-modules/dist/types/index.d.ts'`,
but this result could not be resolved when respecting package.json "exports".
The `'vite-plugin-optimize-css-modules'` library may need to update its package.json or typings. `ts(7016)`

## How do I fix
Follow the linting error message. Update the `package.json`.

**The fix works on my machine, the linting is gone now.**

## Environment
- VSCode: `1.82.2` (commit abd2f3db4bdb28f9e95536dfa84d8479f1eb312d)
- TypeScript: `5.2.2`
- Node.js: `18.18.0`

### Note
The circumstances may vary based on the environment.
